### PR TITLE
ci(e2e): verify applied files match expected list

### DIFF
--- a/.github/scripts/verify-dotfiles.sh
+++ b/.github/scripts/verify-dotfiles.sh
@@ -44,9 +44,10 @@ if [ -n "$CHEZMOI_LOG" ] && [ -f "$CHEZMOI_LOG" ]; then
   echo "Checking applied files match expected list..."
 
   # Parse chezmoi verbose output to extract managed files
-  # Look for lines like "creating file", "updating file", "file already exists"
-  ACTUAL_FILES=$(grep -E '(creating|updating|removing) (file|symlink|directory)' "$CHEZMOI_LOG" | \
-    sed -E 's/.* (file|symlink|directory) (.*)/\2/' | \
+  # chezmoi uses diff format: "diff --git a/.cargo b/.cargo"
+  # Extract the second path (after "b/") and convert to absolute paths
+  ACTUAL_FILES=$(grep -E '^diff --git a/ b/' "$CHEZMOI_LOG" | \
+    sed -E "s|^diff --git a/.* b/(.*)|$HOME/\1|" | \
     sort -u)
 
   # Build expected files list with proper separators for comparison

--- a/.github/scripts/verify-dotfiles.sh
+++ b/.github/scripts/verify-dotfiles.sh
@@ -40,6 +40,9 @@ done
 if [ -n "$CHEZMOI_LOG" ] && [ -f "$CHEZMOI_LOG" ]; then
   echo "Checking applied files match expected list..."
 
+  UNEXPECTED_FILES=""
+  MISSING_FILES=""
+
   mapfile -t APPLIED_ARRAY < <(
     awk '
       /^diff --git a/ { diff_line = $0; next }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
           pacman -Syu --noconfirm --needed chezmoi
       - name: Init and apply dotfiles
         run: |
-          chezmoi init --apply -v sabertazimi
+          chezmoi init --apply -v sabertazimi 2>&1 | tee /tmp/chezmoi-apply.log
       - name: Verify dotfiles
         run: |
-          .github/scripts/verify-dotfiles.sh
+          .github/scripts/verify-dotfiles.sh /tmp/chezmoi-apply.log
 
   publish:
     name: Publish


### PR DESCRIPTION
## Summary

- Capture chezmoi verbose output during `init --apply` to a log file
- Parse applied files from the log and compare against expected file list
- Detect unexpected files (indicates missing `.chezmoiignore` entries)
- Detect missing files (expected but not applied)
- Fail verification if lists don't match

## Context

Previously, the verification only checked that expected files exist. This allowed unintended files to be copied if `.chezmoiignore` was incomplete. The new verification ensures the actual applied files exactly match the expected list.

## Test plan

- [x] Script parses chezmoi verbose output correctly
- [x] Comparison logic handles both unexpected and missing files
- [x] CI workflow runs successfully on this PR